### PR TITLE
#19 [pairwise] Allow blocks to process multiple pairs in hybrid-needleman algorithm

### DIFF
--- a/src/museqa.cpp
+++ b/src/museqa.cpp
@@ -1,4 +1,4 @@
-/** 
+/**
  * Museqa: Multiple Sequence Aligner using hybrid parallel computing.
  * @file The software's entry point.
  * @author Rodrigo Siqueira <rodriados@gmail.com>
@@ -130,7 +130,7 @@ namespace museqa
          * phylogenetic tree, which will then be used to guide the final alignment.
          * @since 0.1.1
          */
-        struct phylogeny : public museqa::phylogeny::module
+        struct phylogeny : public museqa::module::phylogeny
         {
             /**
              * Executes the pipeline module's logic.


### PR DESCRIPTION
Implements #19, allowing a CUDA block to compute more than a single sequence pair at a time. That is, we try to fill the GPU's global memory as much as possible once, and then each block will run multiple times with different data if needed.