### PR TITLE
Fixing inconsistencies with phylogeny's njoining algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ test.cpp
 .hostfile
 .gdb_history
 *junkyard*
+.gdbinit

--- a/src/phylogeny/njoining/njoining.cpp
+++ b/src/phylogeny/njoining/njoining.cpp
@@ -25,9 +25,15 @@ namespace museqa
              * @param b The second join pair candidate to compare.
              * @return The candidate with the minimum distance.
              */
-            auto closest(const joinable& a, const joinable& b) -> joinable
+            static auto closest(const joinable& a, const joinable& b) -> joinable
             {
-                return a.distance > b.distance ? a : b;
+                if(a.distance != b.distance) {
+                    return a.distance > b.distance ? a : b;
+                } else if(a.ref[0] != b.ref[0]) {
+                    return a.ref[0] < b.ref[0] ? a : b;
+                } else {
+                    return a.ref[1] < b.ref[1] ? a : b;
+                }
             }
 
             /**

--- a/src/phylogeny/njoining/star.cuh
+++ b/src/phylogeny/njoining/star.cuh
@@ -62,13 +62,13 @@ namespace museqa
                     {
                         auto& father = m_buffer[parent];
 
-                        const auto& lchild = connect(father, one);
-                        const auto& rchild = connect(father, two);
+                        const auto& c1 = connect(father, one.id < two.id ? one : two);
+                        const auto& c2 = connect(father, one.id < two.id ? two : one);
 
-                        father.child[0] = lchild.id;
-                        father.child[1] = rchild.id;
+                        father.level = utils::max(c1.level, c2.level) + 1;
 
-                        father.level = utils::max(lchild.level, rchild.level) + 1;
+                        father.child[0] = c1.id;
+                        father.child[1] = c2.id;
                     }
 
                     /**

--- a/src/phylogeny/tree.cuh
+++ b/src/phylogeny/tree.cuh
@@ -39,11 +39,13 @@ namespace museqa
 
             protected:
                 using underlying_tree = museqa::tree<T, R>;
-                using node_type = typename underlying_tree::node;
-                using buffer_type = buffer<node_type>;
 
             public:
+                using node_type = typename underlying_tree::node;
                 using reference_type = typename underlying_tree::reference_type;
+
+            protected:
+                using buffer_type = buffer<node_type>;
 
             public:
                 static constexpr reference_type undefined = node_type::undefined;


### PR DESCRIPTION
Inconsistent results are returned when executing the phylogeny module with `njoining` algorithms. After some analysis, it was stated that the original implementation had problems by the time the distance matrix had to be updated for the next iteration.

This happened because the matrix was being updated in-place, which interfered with the produced result. Consequently, the expected result was not seen.